### PR TITLE
Add a patch for the memory leak in Redisson

### DIFF
--- a/src/main/java/uk/ac/cam/cl/retailcategorymapper/api/formdata/FormDataField.java
+++ b/src/main/java/uk/ac/cam/cl/retailcategorymapper/api/formdata/FormDataField.java
@@ -4,6 +4,7 @@ import org.apache.commons.fileupload.FileItemStream;
 import org.apache.commons.fileupload.util.Streams;
 
 import java.io.IOException;
+import java.io.InputStream;
 
 /**
  * A multipart/form-data field.
@@ -19,7 +20,9 @@ public class FormDataField {
         this.name = item.getName();
         this.formField = item.isFormField();
         try {
-            this.contents = Streams.asString(item.openStream());
+            InputStream stream = item.openStream();
+            this.contents = Streams.asString(stream);
+            stream.close();
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/src/main/java/uk/ac/cam/cl/retailcategorymapper/api/routes/HomeRoute.java
+++ b/src/main/java/uk/ac/cam/cl/retailcategorymapper/api/routes/HomeRoute.java
@@ -7,6 +7,6 @@ import spark.Route;
 public class HomeRoute implements Route {
     @Override
     public Object handle(Request request, Response response) throws Exception {
-        return "Retail Category Mapper API";
+        return "Retail Category Mapper API\n";
     }
 }

--- a/src/main/java/uk/ac/cam/cl/retailcategorymapper/db/RedissonWrapper.java
+++ b/src/main/java/uk/ac/cam/cl/retailcategorymapper/db/RedissonWrapper.java
@@ -1,9 +1,13 @@
 package uk.ac.cam.cl.retailcategorymapper.db;
 
 import org.redisson.Config;
+import org.redisson.MasterSlaveServersConfig;
 import org.redisson.Redisson;
 import org.redisson.codec.JsonJacksonCodec;
+import org.redisson.connection.MasterSlaveConnectionManager;
 import uk.ac.cam.cl.retailcategorymapper.config.DbConfig;
+
+import java.lang.reflect.Field;
 
 /**
  * Simple wrapper around Redisson which implements the singleton pattern.
@@ -23,6 +27,7 @@ class RedissonWrapper {
             String address = DbConfig.HOST + ":" + DbConfig.PORT;
             config.useSingleServer().setAddress(address);
             redisson = Redisson.create(config);
+            timeoutPatch(redisson);
         }
         return redisson;
     }
@@ -32,5 +37,67 @@ class RedissonWrapper {
             redisson.shutdown();
             redisson = null;
         }
+    }
+
+    /**
+     * This is a temporary patch to workaround the (temporary) memory leak we
+     * discovered in Redisson.
+     *
+     * When a promise has been fulfilled, the timeout task should be cancelled.
+     * Currently this is not the case and means that the (potentially very
+     * large) amounts of data included in the promise will remain on the heap
+     * until the timeout fires.
+     *
+     * Daniel and Priyesh have reported the issue to the Redisson team
+     * (https://github.com/mrniko/redisson/issues/123) and if this gets fixed
+     * we'll remove this patch and ensure the memory leak has not returned.
+     *
+     * The patch works by setting the timeout to something much lower than
+     * the default of 60 seconds. (The real solution is to have the timeout
+     * task removed when the promise is fulfilled.)
+     *
+     * We need to patch Redisson rather than the Config we provide to Redisson,
+     * as Redisson ignores the timeout set in a SingleServerConfig provided
+     * upon construction.
+     *
+     * @param redisson The Redisson instance to patch.
+     */
+    private static void timeoutPatch(Redisson redisson) {
+        Field cmField;
+        try {
+            cmField = Redisson.class.getDeclaredField("connectionManager");
+        } catch (NoSuchFieldException e) {
+            e.printStackTrace();
+            return;
+        }
+
+        cmField.setAccessible(true);
+        MasterSlaveConnectionManager cm;
+        try {
+            cm = (MasterSlaveConnectionManager) cmField.get(redisson);
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+            return;
+        }
+
+        Field configField;
+        try {
+            configField = MasterSlaveConnectionManager.class.getDeclaredField
+                    ("config");
+        } catch (NoSuchFieldException e) {
+            e.printStackTrace();
+            return;
+        }
+
+        configField.setAccessible(true);
+        MasterSlaveServersConfig config;
+        try {
+            config = (MasterSlaveServersConfig) configField.get(cm);
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+            return;
+        }
+
+        config.setTimeout(3000);
     }
 }


### PR DESCRIPTION
This is a temporary (ugly) patch to workaround the (temporary) memory leak we discovered in Redisson.

When a promise has been fulfilled, the timeout task should be cancelled. Currently this is not the case and means that the (potentially very large) amounts of data included in the promise will remain on the heap until the timeout fires.

Daniel and I have reported the issue to the Redisson team (https://github.com/mrniko/redisson/issues/123) and if this gets fixed we'll remove this patch and ensure the memory leak has not returned.

The patch works by setting the timeout to something much lower than the default of 60 seconds. (The real solution is to have the timeout task removed when the promise is fulfilled.)

We need to patch Redisson rather than the `Config` we provide to Redisson, as Redisson ignores the timeout set in a `SingleServerConfig` provided upon construction.
